### PR TITLE
snmp: Improve handling of OIDs

### DIFF
--- a/snmp/file_handler.go
+++ b/snmp/file_handler.go
@@ -66,6 +66,11 @@ func (h *FileHandler) Get(oids []string) (result *gosnmp.SnmpPacket, err error) 
 	}
 
 	for _, oid := range oids {
+		oid, err = EnsureValidOid(oid)
+		if err != nil {
+			return
+		}
+
 		if pdu, ok := h.Data[oid]; ok {
 			result.Variables = append(result.Variables, *pdu)
 		}
@@ -87,6 +92,11 @@ func (h *FileHandler) GetNext(oids []string) (result *gosnmp.SnmpPacket, err err
 
 // Simulating Walk() behavior by searching read in data
 func (h *FileHandler) Walk(rootOid string, walkFn gosnmp.WalkFunc) (err error) {
+	rootOid, err = EnsureValidOid(rootOid)
+	if err != nil {
+		return
+	}
+
 	for oid, pdu := range h.Data {
 		if !IsOidPartOf(oid, rootOid) {
 			continue

--- a/snmp/file_handler_test.go
+++ b/snmp/file_handler_test.go
@@ -25,4 +25,39 @@ func TestFileHandler_Walk(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, counter, 11)
+
+	// without leading dot
+	counter = 0
+	err = h.Walk("1.3.6.1.2.1.2.2.1.1", func(pdu gosnmp.SnmpPDU) error {
+		counter++
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, counter, 11)
+}
+
+func TestFileHandler_Get(t *testing.T) {
+	h, err := NewFileHandlerFromFile("testdata/if-mib.txt")
+	assert.NoError(t, err)
+
+	oid := ".1.3.6.1.2.1.2.2.1.3.1"
+
+	p, err := h.Get([]string{oid})
+	assert.NoError(t, err)
+
+	assert.Len(t, p.Variables, 1)
+
+	pdu := p.Variables[0]
+	assert.Equal(t, oid, pdu.Name)
+	assert.Equal(t, gosnmp.Integer, pdu.Type)
+	assert.Equal(t, 24, pdu.Value)
+
+	// without leading dot
+	oid = "1.3.6.1.2.1.2.2.1.3.1"
+
+	p, err = h.Get([]string{oid})
+	assert.NoError(t, err)
+
+	assert.Len(t, p.Variables, 1)
 }

--- a/snmp/snmpwalk.go
+++ b/snmp/snmpwalk.go
@@ -63,6 +63,11 @@ func ParseWalkLine(line string) (pdu *gosnmp.SnmpPDU, err error) {
 		return
 	}
 
+	err = IsValidOid(parts[0])
+	if err != nil {
+		return
+	}
+
 	pdu = &gosnmp.SnmpPDU{
 		Name: parts[0],
 	}
@@ -139,4 +144,36 @@ func ParseWalkLine(line string) (pdu *gosnmp.SnmpPDU, err error) {
 	}
 
 	return
+}
+
+// Test if an OID is in a valid format like `.1.23.456`
+func IsValidOid(oid string) error {
+	if len(oid) == 0 {
+		return fmt.Errorf("oid is empty")
+	} else if oid[0] != '.' {
+		return fmt.Errorf("invalid oid, must begin with a dot: %s", oid)
+	}
+
+	chars := 0
+
+	for _, c := range oid {
+		chars++
+
+		if c != '.' && !(c >= '0' && c <= '9') {
+			return fmt.Errorf("illegal char #%d in oid: %s", chars, oid)
+		}
+	}
+
+	return nil
+}
+
+// Test an OID, but prefix a missing dot
+//
+// Useful to be compatible with the base implementation of SNMP, where it is optional.
+func EnsureValidOid(oid string) (string, error) {
+	if oid[0] != '.' {
+		oid = "." + oid
+	}
+
+	return oid, IsValidOid(oid)
 }

--- a/snmp/snmpwalk_test.go
+++ b/snmp/snmpwalk_test.go
@@ -12,3 +12,20 @@ func TestReadWalk(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, testWalkLength, len(h.Data))
 }
+
+func TestIsValidOid(t *testing.T) {
+	assert.NoError(t, IsValidOid(".1.2.3.4.6.999999"))
+	assert.Error(t, IsValidOid(""))
+	assert.Error(t, IsValidOid("1.2.3.4"))
+	assert.Error(t, IsValidOid(".a.b.c.d"))
+}
+
+func TestEnsureValidOid(t *testing.T) {
+	oid, err := EnsureValidOid("1.2.3.4.6.999999")
+	assert.NoError(t, err)
+	assert.Equal(t, ".1.2.3.4.6.999999", oid)
+
+	oid, err = EnsureValidOid(".1.2.3.4.6.999999")
+	assert.NoError(t, err)
+	assert.Equal(t, ".1.2.3.4.6.999999", oid)
+}


### PR DESCRIPTION
- On reading a walk, ensure the OID is valid
- Get/Walk treat the leading dot in OID as optional