### PR TITLE
Add support for ilo ripple20 vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please see support documents from HPE:
 * [a00092491](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-a00092491en_us)
 * [a00097382](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us)
 * [a00097210](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097210en_us)
-* [HPESBHF04012 ](https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us)
+* [HPESBHF04012](https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us)
 
 **IMPORTANT:** Read the documentation for HPE! The plugin and its documentation is a best effort to find and detect
 affected hardware. There is ABSOLUTELY NO WARRANTY, see the license!
@@ -65,9 +65,9 @@ Arguments:
       -P, --protocol string        SNMP protocol (default "2c")
           --timeout int            SNMP timeout in seconds (default 15)
           --snmpwalk-file string   Read output from snmpwalk
+          --ignore-ilo-version     Don't check the ILO version
       -4, --ipv4                   Use IPv4
       -6, --ipv6                   Use IPv6
-      -I  --ilo                    Checks the version of iLo
       -V, --version                Show version
           --debug                  Enable debug output
 
@@ -94,6 +94,7 @@ You can download or build the project locally with go:
 ## Example
 
     OK - All 2 controllers and 33 drives seem fine
+    [OK] Integrated Lights-Out 5 revision 2.18 - version newer than affected
     [OK] controller (0) model=p816i-a serial=XXX firmware=1.65 - firmware older than affected
     [OK] controller (4) model=p408e-p serial=XXX firmware=1.65 - firmware older than affected
     [OK] (0.9 ) model=MO003200JWFWR serial=XXX firmware=HPD2 hours=8086
@@ -147,9 +148,9 @@ so we can provide you with a secure upload link, that won't be shared with publi
 
 ## Technical Details
 
-Supported hardware is split into modules: [hp/cntlr](hp/cntlr) [hp/phy_drv](hp/phy_drv)
+Supported hardware is split into modules: [hp/cntlr](hp/cntlr) [hp/phy_drv](hp/phy_drv) [hp/ilo](hp/ilo)
 
-Known models and affected firmware is documented in: [hp/cntlr/firmware_data.go](hp/cntlr/firmware_data.go) [hp/phy_drv/firmware_data.go](hp/phy_drv/firmware_data.go)
+Known models and affected firmware is documented in: [hp/cntlr/firmware_data.go](hp/cntlr/firmware_data.go) [hp/phy_drv/firmware_data.go](hp/phy_drv/firmware_data.go) [hp/ilo/firmware_data.go](hp/ilo/firmware_data.go)
 
 This data can be easily enhanced in the future. Make sure to document source documents and versions as well, and check
 the accompanying firmware and status functions.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,24 @@ plugin does not verify configured logical drives, but we believe you should upda
 The check will raise a CRITICAL when the drive needs to be updated with the note `affected by FW bug`, and when
 the drive is patched with `firmware update applied`.
 
+**HPE Integrated Lights-Out**
+
+Multiple security vulnerabilities have been identified in Integrated Lights-Out 3 (iLO 3),
+Integrated Lights-Out 4 (iLO 4), and Integrated Lights-Out 5 (iLO 5) firmware. The vulnerabilities could be remotely
+exploited to execute code, cause denial of service, and expose sensitive information. HPE has released updated
+firmware to mitigate these vulnerabilities.
+
+The check will raise a CRITICAL when the Integrated Lights-Out needs to be updated. Below you will find a list with
+the least version of each Integrated Lights-Out version:
+- HPE Integrated Lights-Out 3 (iLO 3) firmware v1.93 or later.
+- HPE Integrated Lights-Out 4 (iLO 4) firmware v2.75 or later
+- HPE Integrated Lights-Out 5 (iLO 5) firmware v2.18 or later.
+
 Please see support documents from HPE:
 * [a00092491](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-a00092491en_us)
 * [a00097382](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us)
 * [a00097210](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097210en_us)
+* [HPESBHF04012 ](https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us)
 
 **IMPORTANT:** Read the documentation for HPE! The plugin and its documentation is a best effort to find and detect
 affected hardware. There is ABSOLUTELY NO WARRANTY, see the license!
@@ -53,6 +67,7 @@ Arguments:
           --snmpwalk-file string   Read output from snmpwalk
       -4, --ipv4                   Use IPv4
       -6, --ipv6                   Use IPv6
+      -I  --ilo                    Checks the version of iLo
       -V, --version                Show version
           --debug                  Enable debug output
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.13
 
 require (
 	github.com/gosnmp/gosnmp v1.30.0
+	github.com/hashicorp/go-version v1.3.0
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210326220804-49726bf1d181 // indirect
+	github.com/hashicorp/go-version v1.2.1
 )

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,4 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210326220804-49726bf1d181 // indirect
-	github.com/hashicorp/go-version v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,11 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/gosnmp/gosnmp v1.30.0 h1:P6uUvPaoZCZh2EXvSUIgsxYZ1vdD/Sonl2BSVCGieG8=
 github.com/gosnmp/gosnmp v1.30.0/go.mod h1:EIp+qkEpXoVsyZxXKy0AmXQx0mCHMMcIhXXvNDMpgF0=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEdvY3iDK6jfWXvEaM5OCKkjxPKoJRdB3Gg=
 github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -15,7 +16,6 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -33,3 +33,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/go.sum
+++ b/go.sum
@@ -33,5 +33,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
-github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/hp/ilo/firmware.go
+++ b/hp/ilo/firmware.go
@@ -1,0 +1,84 @@
+package ilo
+
+import (
+	"fmt"
+	"github.com/NETWAYS/check_hp_firmware/hp/mib"
+	"github.com/NETWAYS/check_hp_firmware/nagios"
+	"github.com/gosnmp/gosnmp"
+	"github.com/hashicorp/go-version"
+)
+
+type Ilo struct {
+	Model       string
+	RomRevision string
+}
+
+func GetIloInformation(client gosnmp.Handler) (int, string)  {
+	oidModel := []string{mib.CpqSm2CntlrModel + ".0"}
+	oidRev := []string{ mib.CpqSm2CntlrRomRevision + ".0"}
+
+	ilo := &Ilo{}
+	parseErr := ""
+
+	iloModel, err := client.Get(oidModel)
+	if err != nil {
+		return nagios.Critical, parseErr + "could not get model for Ilo"
+	}
+
+	iloRev, err := client.Get(oidRev)
+	if err != nil {
+		return nagios.Critical, parseErr + "could not get revision for Ilo"
+	} else {
+		ilo.RomRevision = iloRev.Variables[0].Value.(string)
+	}
+
+	if iloModel, ok := mib.CpqSm2CntlrModelMap[iloModel.Variables[0].Value.(int)]; ok {
+		ilo.Model = iloModel
+	} else {
+		return nagios.Critical, parseErr + "unknown Ilo model"
+	}
+
+	description := fmt.Sprintf("Integrated Lights-Out=%s Revision=%s ", ilo.Model, ilo.RomRevision)
+
+	if ilo.Model == "3" {
+		if ( ! CompareVer("1.93", iloRev.Variables[0].Value.(string))) {
+			return nagios.Critical, description +
+				fmt.Sprintf("The Revision: %s does not satisfies constraints 1.93. Update Firmware immediately!",
+				ilo.RomRevision)
+		}
+	} else if ilo.Model == "4" {
+		if ( ! CompareVer("2.75", iloRev.Variables[0].Value.(string))) {
+			return nagios.Critical, description +
+				fmt.Sprintf("The Revision: %s does not satisfies constraints 2.75 Update Firmware immediately!",
+				ilo.RomRevision)
+		}
+	} else if ilo.Model == "5" {
+		if ( ! CompareVer("2.18", iloRev.Variables[0].Value.(string))) {
+			return nagios.Critical, description +
+				fmt.Sprintf("The Revision: %s does not satisfies constraints 2.18 Update Firmware immediately!",
+				ilo.RomRevision)
+		}
+	} else {
+		return nagios.Critical, description + fmt.Sprintf("the Ilo Version is to old")
+	}
+
+	return nagios.OK, description + fmt.Sprintf("The Revision:%s satisfies constraints", ilo.RomRevision)
+}
+
+func CompareVer(constr, vers string) (ret bool) {
+	v, err := version.NewVersion(vers)
+	if err != nil{
+		return false
+	}
+
+	c, err := version.NewConstraint(">=" + constr)
+	if err != nil {
+		return false
+	}
+
+	if c.Check(v) {
+		return true
+	}
+
+	return false
+}

--- a/hp/ilo/firmware_data.go
+++ b/hp/ilo/firmware_data.go
@@ -1,0 +1,19 @@
+package ilo
+
+type PlatformInfo struct {
+	Name         string
+	FixedRelease string
+}
+
+// OlderModels or lower ids are too old to be safe and should be alerted
+const OlderModels = 8
+
+// FixedVersionMap lists the version for which the platform has been fixed by generation
+// See mib.CpqSm2CntlrModelMap - not all models are mentioned here
+//
+// For vendor details see HPESBHF04012 https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us
+var FixedVersionMap = map[string]PlatformInfo{
+	"pciIntegratedLightsOutRemoteInsight3": {"3", "1.93"},
+	"pciIntegratedLightsOutRemoteInsight4": {"4", "2.75"},
+	"pciIntegratedLightsOutRemoteInsight5": {"5", "2.18"},
+}

--- a/hp/ilo/firmware_test.go
+++ b/hp/ilo/firmware_test.go
@@ -1,0 +1,42 @@
+package ilo
+
+import (
+	"github.com/NETWAYS/check_hp_firmware/nagios"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIlo_GetNagiosStatus(t *testing.T) {
+	ilo := Ilo{
+		Model:       "pciIntegratedLightsOutRemoteInsight3",
+		ModelID:     9,
+		RomRevision: "1.40",
+	}
+
+	state, output := ilo.GetNagiosStatus()
+	assert.Equal(t, nagios.Critical, state)
+	assert.Contains(t, output, "too old")
+
+	ilo.RomRevision = "2.18"
+	state, output = ilo.GetNagiosStatus()
+	assert.Equal(t, nagios.OK, state)
+	assert.Contains(t, output, "2.18")
+
+	ilo.Model = "pciIntegratedLightsOutRemoteInsight2"
+	ilo.ModelID = 7
+	state, output = ilo.GetNagiosStatus()
+	assert.Equal(t, nagios.Critical, state)
+	assert.Contains(t, output, "pretty old")
+
+	ilo.Model = "someNewerModel"
+	ilo.ModelID = 12
+	state, output = ilo.GetNagiosStatus()
+	assert.Equal(t, nagios.OK, state)
+	assert.Contains(t, output, "not known")
+}
+
+func TestCompareVer(t *testing.T) {
+	assert.True(t, CompareVersion("1.0", "1.0"))
+	assert.True(t, CompareVersion("1.0", "1.1"))
+	assert.False(t, CompareVersion("1.0", "0.9"))
+}

--- a/hp/mib/SOURCE.md
+++ b/hp/mib/SOURCE.md
@@ -4,3 +4,11 @@ Quick reference: http://www.oidview.com/mibs/232/CPQIDA-MIB.html
 
 MIB is downloadable from "HPE Systems Insight Manager - MIB Kit" - Version 11.40
 https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c04272529
+
+## CPQSM2-MIB
+
+Quick reference: http://www.oidview.com/mibs/232/CPQSM2-MIB.html
+
+MIB is downloadable from "HPE Systems Insight Manager - MIB Kit" - Version 11.40
+https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-c04272529
+

--- a/hp/mib/cpq_sm_cntrl.go
+++ b/hp/mib/cpq_sm_cntrl.go
@@ -2,57 +2,50 @@ package mib
 
 //noinspection GoUnusedConst,SpellCheckingInspection
 const (
-	CpqSm2Cntlr				  = `.1.3.6.1.4.1.232.9.2.2`
-	CpqSm2CntlrRomDate			  = `.1.3.6.1.4.1.232.9.2.2.1`
-	CpqSm2CntlrRomRevision			  = `.1.3.6.1.4.1.232.9.2.2.2`
-	CpqSm2CntlrVideoStatus			  = `.1.3.6.1.4.1.232.9.2.2.3`
-	CpqSm2CntlrBatteryEnabled		  = `.1.3.6.1.4.1.232.9.2.2.4`
-	CpqSm2CntlrBatteryStatus		  = `.1.3.6.1.4.1.232.9.2.2.5`
-	CpqSm2CntlrBatteryPercentCharged	  = `.1.3.6.1.4.1.232.9.2.2.6`
-	CpqSm2CntlrAlertStatus			  = `.1.3.6.1.4.1.232.9.2.2.7`
-	CpqSm2CntlrPendingAlerts		  = `.1.3.6.1.4.1.232.9.2.2.8`
-	CpqSm2CntlrSelfTestErrors		  = `.1.3.6.1.4.1.232.9.2.2.9`
-	CpqSm2CntlrAgentLocation		  = `.1.3.6.1.4.1.232.9.2.2.10`
-	CpqSm2CntlrLastDataUpdate 		  = `.1.3.6.1.4.1.232.9.2.2.11`
-	CpqSm2CntlrDataStatus 			  = `.1.3.6.1.4.1.232.9.2.2.12`
-	CpqSm2CntlrColdReboot 			  = `.1.3.6.1.4.1.232.9.2.2.13`
-	CpqSm2CntlrBadLoginAttemptsThresh 	  = `.1.3.6.1.4.1.232.9.2.2.14`
-	CpqSm2CntlrBoardSerialNumber 		  = `.1.3.6.1.4.1.232.9.2.2.15`
-	CpqSm2CntlrRemoteSessionStatus 		  = `.1.3.6.1.4.1.232.9.2.2.16`
-	CpqSm2CntlrInterfaceStatus 		  = `.1.3.6.1.4.1.232.9.2.2.17`
-	CpqSm2CntlrSystemId 			  = `.1.3.6.1.4.1.232.9.2.2.18`
-	CpqSm2CntlrKeyboardCableStatus 		  = `.1.3.6.1.4.1.232.9.2.2.19`
-	CpqSm2ServerIpAddress 			  = `.1.3.6.1.4.1.232.9.2.2.20`
-	CpqSm2CntlrModel 			  = `.1.3.6.1.4.1.232.9.2.2.21`
-	CpqSm2CntlrSelfTestErrorMask 		  = `.1.3.6.1.4.1.232.9.2.2.22`
-	CpqSm2CntlrMouseCableStatus 		  = `.1.3.6.1.4.1.232.9.2.2.23`
-	CpqSm2CntlrVirtualPowerCableStatus 	  = `.1.3.6.1.4.1.232.9.2.2.24`
-	CpqSm2CntlrExternalPowerCableStatus 	  = `.1.3.6.1.4.1.232.9.2.2.25`
-	CpqSm2CntlrHostGUID 			  = `.1.3.6.1.4.1.232.9.2.2.26`
+	CpqSm2Cntlr                               = `.1.3.6.1.4.1.232.9.2.2`
+	CpqSm2CntlrRomDate                        = `.1.3.6.1.4.1.232.9.2.2.1`
+	CpqSm2CntlrRomRevision                    = `.1.3.6.1.4.1.232.9.2.2.2`
+	CpqSm2CntlrVideoStatus                    = `.1.3.6.1.4.1.232.9.2.2.3`
+	CpqSm2CntlrBatteryEnabled                 = `.1.3.6.1.4.1.232.9.2.2.4`
+	CpqSm2CntlrBatteryStatus                  = `.1.3.6.1.4.1.232.9.2.2.5`
+	CpqSm2CntlrBatteryPercentCharged          = `.1.3.6.1.4.1.232.9.2.2.6`
+	CpqSm2CntlrAlertStatus                    = `.1.3.6.1.4.1.232.9.2.2.7`
+	CpqSm2CntlrPendingAlerts                  = `.1.3.6.1.4.1.232.9.2.2.8`
+	CpqSm2CntlrSelfTestErrors                 = `.1.3.6.1.4.1.232.9.2.2.9`
+	CpqSm2CntlrAgentLocation                  = `.1.3.6.1.4.1.232.9.2.2.10`
+	CpqSm2CntlrLastDataUpdate                 = `.1.3.6.1.4.1.232.9.2.2.11`
+	CpqSm2CntlrDataStatus                     = `.1.3.6.1.4.1.232.9.2.2.12`
+	CpqSm2CntlrColdReboot                     = `.1.3.6.1.4.1.232.9.2.2.13`
+	CpqSm2CntlrBadLoginAttemptsThresh         = `.1.3.6.1.4.1.232.9.2.2.14`
+	CpqSm2CntlrBoardSerialNumber              = `.1.3.6.1.4.1.232.9.2.2.15`
+	CpqSm2CntlrRemoteSessionStatus            = `.1.3.6.1.4.1.232.9.2.2.16`
+	CpqSm2CntlrInterfaceStatus                = `.1.3.6.1.4.1.232.9.2.2.17`
+	CpqSm2CntlrSystemId                       = `.1.3.6.1.4.1.232.9.2.2.18`
+	CpqSm2CntlrKeyboardCableStatus            = `.1.3.6.1.4.1.232.9.2.2.19`
+	CpqSm2ServerIpAddress                     = `.1.3.6.1.4.1.232.9.2.2.20`
+	CpqSm2CntlrModel                          = `.1.3.6.1.4.1.232.9.2.2.21`
+	CpqSm2CntlrSelfTestErrorMask              = `.1.3.6.1.4.1.232.9.2.2.22`
+	CpqSm2CntlrMouseCableStatus               = `.1.3.6.1.4.1.232.9.2.2.23`
+	CpqSm2CntlrVirtualPowerCableStatus        = `.1.3.6.1.4.1.232.9.2.2.24`
+	CpqSm2CntlrExternalPowerCableStatus       = `.1.3.6.1.4.1.232.9.2.2.25`
+	CpqSm2CntlrHostGUID                       = `.1.3.6.1.4.1.232.9.2.2.26`
 	CpqSm2CntlriLOSecurityOverrideSwitchState = `.1.3.6.1.4.1.232.9.2.2.27`
-	CpqSm2CntlrHardwareVer 			  = `.1.3.6.1.4.1.232.9.2.2.28`
-	CpqSm2CntlrAction 			  = `.1.3.6.1.4.1.232.9.2.2.29`
-	CpqSm2CntlrLicenseActive 		  = `.1.3.6.1.4.1.232.9.2.2.30`
-	CpqSm2CntlrLicenseKey 			  = `.1.3.6.1.4.1.232.9.2.2.31`
+	CpqSm2CntlrHardwareVer                    = `.1.3.6.1.4.1.232.9.2.2.28`
+	CpqSm2CntlrAction                         = `.1.3.6.1.4.1.232.9.2.2.29`
+	CpqSm2CntlrLicenseActive                  = `.1.3.6.1.4.1.232.9.2.2.30`
+	CpqSm2CntlrLicenseKey                     = `.1.3.6.1.4.1.232.9.2.2.31`
 )
 
 var CpqSm2CntlrModelMap = StringMap{
 	1:  "other",
-	2:  "eisaRemoteInsightBoard",		    // This is the EISA Remote Insight
-	3:  "pciRemoteInsightBoard", 		    // This is the PCI Remote Insight
-	4:  "pciLightsOutRemoteInsightBoard",       // This is the Remote Insight Lights-Out Edition
-	5:  "pciIntegratedLightsOutRemoteInsight",  // This is Integrated Remote Insight Lights-Out Edition.
-	6:  "pciLightsOutRemoteInsightBoardII",     // This is the Remote Insight Lights-Out Edition version II
-	7:  "2", 				    // This is the Integrated Lights-Out 2 Edition
-						    // "pciIntegratedLightsOutRemoteInsight2"
-
-	8:  "pciLightsOut100series",		    // This is the Lights-Out 100 Edition for 100 Series of ProLiant servers
-	9:  "3", 				    // This is the Integrated Lights-Out 3 Edition
-						    // "pciIntegratedLightsOutRemoteInsight3"
-
-	10: "4", 				    // This is the Integrated Lights-Out 4 Edition
-						    // "pciIntegratedLightsOutRemoteInsight4"
-
-	11: "5", 				    // This is the Integrated Lights-Out 5 Edition
-						    // "pciIntegratedLightsOutRemoteInsight5"
+	2:  "eisaRemoteInsightBoard",               // EISA Remote Insight
+	3:  "pciRemoteInsightBoard",                // PCI Remote Insight
+	4:  "pciLightsOutRemoteInsightBoard",       // Remote Insight Lights-Out Edition
+	5:  "pciIntegratedLightsOutRemoteInsight",  // Integrated Remote Insight Lights-Out Edition.
+	6:  "pciLightsOutRemoteInsightBoardII",     // Remote Insight Lights-Out Edition version II
+	7:  "pciIntegratedLightsOutRemoteInsight2", // Integrated Lights-Out 2 Edition
+	8:  "pciLightsOut100series",                // Lights-Out 100 Edition for 100 Series of ProLiant servers
+	9:  "pciIntegratedLightsOutRemoteInsight3", // Integrated Lights-Out 3 Edition
+	10: "pciIntegratedLightsOutRemoteInsight4", // Integrated Lights-Out 4 Edition
+	11: "pciIntegratedLightsOutRemoteInsight5", // Integrated Lights-Out 5 Edition
 }

--- a/hp/mib/cpq_sm_cntrl.go
+++ b/hp/mib/cpq_sm_cntrl.go
@@ -1,0 +1,58 @@
+package mib
+
+//noinspection GoUnusedConst,SpellCheckingInspection
+const (
+	CpqSm2Cntlr				  = `.1.3.6.1.4.1.232.9.2.2`
+	CpqSm2CntlrRomDate			  = `.1.3.6.1.4.1.232.9.2.2.1`
+	CpqSm2CntlrRomRevision			  = `.1.3.6.1.4.1.232.9.2.2.2`
+	CpqSm2CntlrVideoStatus			  = `.1.3.6.1.4.1.232.9.2.2.3`
+	CpqSm2CntlrBatteryEnabled		  = `.1.3.6.1.4.1.232.9.2.2.4`
+	CpqSm2CntlrBatteryStatus		  = `.1.3.6.1.4.1.232.9.2.2.5`
+	CpqSm2CntlrBatteryPercentCharged	  = `.1.3.6.1.4.1.232.9.2.2.6`
+	CpqSm2CntlrAlertStatus			  = `.1.3.6.1.4.1.232.9.2.2.7`
+	CpqSm2CntlrPendingAlerts		  = `.1.3.6.1.4.1.232.9.2.2.8`
+	CpqSm2CntlrSelfTestErrors		  = `.1.3.6.1.4.1.232.9.2.2.9`
+	CpqSm2CntlrAgentLocation		  = `.1.3.6.1.4.1.232.9.2.2.10`
+	CpqSm2CntlrLastDataUpdate 		  = `.1.3.6.1.4.1.232.9.2.2.11`
+	CpqSm2CntlrDataStatus 			  = `.1.3.6.1.4.1.232.9.2.2.12`
+	CpqSm2CntlrColdReboot 			  = `.1.3.6.1.4.1.232.9.2.2.13`
+	CpqSm2CntlrBadLoginAttemptsThresh 	  = `.1.3.6.1.4.1.232.9.2.2.14`
+	CpqSm2CntlrBoardSerialNumber 		  = `.1.3.6.1.4.1.232.9.2.2.15`
+	CpqSm2CntlrRemoteSessionStatus 		  = `.1.3.6.1.4.1.232.9.2.2.16`
+	CpqSm2CntlrInterfaceStatus 		  = `.1.3.6.1.4.1.232.9.2.2.17`
+	CpqSm2CntlrSystemId 			  = `.1.3.6.1.4.1.232.9.2.2.18`
+	CpqSm2CntlrKeyboardCableStatus 		  = `.1.3.6.1.4.1.232.9.2.2.19`
+	CpqSm2ServerIpAddress 			  = `.1.3.6.1.4.1.232.9.2.2.20`
+	CpqSm2CntlrModel 			  = `.1.3.6.1.4.1.232.9.2.2.21`
+	CpqSm2CntlrSelfTestErrorMask 		  = `.1.3.6.1.4.1.232.9.2.2.22`
+	CpqSm2CntlrMouseCableStatus 		  = `.1.3.6.1.4.1.232.9.2.2.23`
+	CpqSm2CntlrVirtualPowerCableStatus 	  = `.1.3.6.1.4.1.232.9.2.2.24`
+	CpqSm2CntlrExternalPowerCableStatus 	  = `.1.3.6.1.4.1.232.9.2.2.25`
+	CpqSm2CntlrHostGUID 			  = `.1.3.6.1.4.1.232.9.2.2.26`
+	CpqSm2CntlriLOSecurityOverrideSwitchState = `.1.3.6.1.4.1.232.9.2.2.27`
+	CpqSm2CntlrHardwareVer 			  = `.1.3.6.1.4.1.232.9.2.2.28`
+	CpqSm2CntlrAction 			  = `.1.3.6.1.4.1.232.9.2.2.29`
+	CpqSm2CntlrLicenseActive 		  = `.1.3.6.1.4.1.232.9.2.2.30`
+	CpqSm2CntlrLicenseKey 			  = `.1.3.6.1.4.1.232.9.2.2.31`
+)
+
+var CpqSm2CntlrModelMap = StringMap{
+	1:  "other",
+	2:  "eisaRemoteInsightBoard",		    // This is the EISA Remote Insight
+	3:  "pciRemoteInsightBoard", 		    // This is the PCI Remote Insight
+	4:  "pciLightsOutRemoteInsightBoard",       // This is the Remote Insight Lights-Out Edition
+	5:  "pciIntegratedLightsOutRemoteInsight",  // This is Integrated Remote Insight Lights-Out Edition.
+	6:  "pciLightsOutRemoteInsightBoardII",     // This is the Remote Insight Lights-Out Edition version II
+	7:  "2", 				    // This is the Integrated Lights-Out 2 Edition
+						    // "pciIntegratedLightsOutRemoteInsight2"
+
+	8:  "pciLightsOut100series",		    // This is the Lights-Out 100 Edition for 100 Series of ProLiant servers
+	9:  "3", 				    // This is the Integrated Lights-Out 3 Edition
+						    // "pciIntegratedLightsOutRemoteInsight3"
+
+	10: "4", 				    // This is the Integrated Lights-Out 4 Edition
+						    // "pciIntegratedLightsOutRemoteInsight4"
+
+	11: "5", 				    // This is the Integrated Lights-Out 5 Edition
+						    // "pciIntegratedLightsOutRemoteInsight5"
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/NETWAYS/check_hp_firmware/hp/cntlr"
+	"github.com/NETWAYS/check_hp_firmware/hp/ilo"
 	"github.com/NETWAYS/check_hp_firmware/hp/phy_drv"
 	"github.com/NETWAYS/check_hp_firmware/nagios"
 	"github.com/NETWAYS/check_hp_firmware/snmp"
@@ -15,7 +16,7 @@ import (
 )
 
 const Readme = `
-Icinga / Nagios check plugin to verify HPE controllers an SSD disks are not affected by certain vulnerabilities.
+Icinga / Nagios check plugin to verify HPE controllers an SSD disks or ilo are not affected by certain vulnerabilities.
 
 **HPE Controllers**
 
@@ -42,10 +43,24 @@ plugin does not verify configured logical drives, but we believe you should upda
 The check will raise a CRITICAL when the drive needs to be updated with the note "affected by FW bug", and when
 the drive is patched with "firmware update applied".
 
+**HPE Integrated Lights-Out**
+  Multiple security vulnerabilities have been identified in Integrated Lights-Out 3 (iLO 3),
+  Integrated Lights-Out 4 (iLO 4), and Integrated Lights-Out 5 (iLO 5) firmware. The vulnerabilities could be remotely
+  exploited to execute code, cause denial of service, and expose sensitive information. HPE has released updated
+  firmware to mitigate these vulnerabilities.
+
+  The check will raise a CRITICAL when the Integrated Lights-Out needs to be updated. Below you will find a list with
+  the least version of each Integrated Lights-Out version:
+   - HPE Integrated Lights-Out 3 (iLO 3) firmware v1.93 or later.
+   - HPE Integrated Lights-Out 4 (iLO 4) firmware v2.75 or later
+   - HPE Integrated Lights-Out 5 (iLO 5) firmware v2.18 or later.
+
+
 Please see support documents from HPE:
 * https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-a00092491en_us
 * https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us
 * https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097210en_us
+* https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us
 
 **IMPORTANT:** Read the documentation for HPE! The plugin and its documentation is a best effort to find and detect
 affected hardware. There is ABSOLUTELY NO WARRANTY, see the license!
@@ -64,6 +79,7 @@ func main() {
 	timeout := flagSet.Int64("timeout", 15, "SNMP timeout in seconds")
 
 	file := flagSet.String("snmpwalk-file", "", "Read output from snmpwalk")
+	checkIlo := flagSet.BoolP("ilo", "I", false, "Checks the version of iLo")
 
 	ipv4 := flagSet.BoolP("ipv4", "4", false, "Use IPv4")
 	ipv6 := flagSet.BoolP("ipv6", "6", false, "Use IPv6")
@@ -194,6 +210,13 @@ func main() {
 		overall.Add(driveStatus, desc)
 
 		countDrives += 1
+	}
+
+	// ILo Data
+
+	if *checkIlo {
+		iloStatus, desc := ilo.GetIloInformation(client)
+		overall.Add(iloStatus, desc)
 	}
 
 	var summary string


### PR DESCRIPTION
Adds the functionality/parameter to check the iLO for the [ripple20 vulnerability](https://support.hpe.com/hpesc/public/docDisplay?docId=hpesbhf04012en_us).