### PR TITLE
Remove unused --ilo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Arguments:
 -P, --protocol string        SNMP protocol (default "2c")
     --timeout int            SNMP timeout in seconds (default 15)
     --snmpwalk-file string   Read output from snmpwalk
-    --ignore-ilo-version     Don't check the ILO version
+-I, --ignore-ilo-version     Don't check the ILO version
 -4, --ipv4                   Use IPv4
 -6, --ipv6                   Use IPv6
 -V, --version                Show version

--- a/main.go
+++ b/main.go
@@ -50,14 +50,10 @@ func main() {
 		community = fs.StringP("community", "c", "public", "SNMP community")
 		protocol  = fs.StringP("protocol", "P", "2c", "SNMP protocol")
 		file      = fs.String("snmpwalk-file", "", "Read output from snmpwalk")
-		ignoreIlo = fs.Bool("ignore-ilo-version", false, "Don't check the ILO version")
+		ignoreIlo = fs.BoolP("ignore-ilo-version", "I", false, "Don't check the ILO version")
 		ipv4      = fs.BoolP("ipv4", "4", false, "Use IPv4")
 		ipv6      = fs.BoolP("ipv6", "6", false, "Use IPv6")
 	)
-
-	// TODO What's the use of this hidden flag?
-	_ = fs.BoolP("ilo", "I", false, "Checks the version of iLo")
-	_ = fs.MarkHidden("ilo")
 
 	config.ParseArguments()
 


### PR DESCRIPTION
Couldn't find any reference to the flag. I assumed it remained for backwards compatibility, but it was never used somewhere.